### PR TITLE
Fix compiler issues when it tries to Parse ObjC as C code

### DIFF
--- a/OpenSSL-iOS/OpenSSL-iOS/openssl.h
+++ b/OpenSSL-iOS/OpenSSL-iOS/openssl.h
@@ -6,6 +6,8 @@
 //  Copyright © 2016 krzyzanowskim. All rights reserved.
 //
 
+#ifdef __OBJC__
+
 #import <Foundation/Foundation.h>
 
 //! Project version number for OpenSSL-iOS.
@@ -13,6 +15,8 @@ FOUNDATION_EXPORT double OpenSSL_iOSVersionNumber;
 
 //! Project version string for OpenSSL-iOS.
 FOUNDATION_EXPORT const unsigned char OpenSSL_iOSVersionString[];
+
+#endif
 
 // In this header, you should import all the public headers of your framework using statements like #import <OpenSSL_iOS/PublicHeader.h>
 


### PR DESCRIPTION
Hi levigroker!

Thank you for maintaining this awesome repo. It really helps to integrate OpenSSL as dynamic framework.

Basically, I'm using as `GRKOpenSSLFramework` pod as dependency in Themis podspec. There're other apps that include Themis pod inside. Unfortunately, when Xcode setting is 'CLANG_ENABLE_MODULES' = YES, those apps are failing for compile. Adding OBJC check around Foundation import solves this problem.

Read moar:
https://stackoverflow.com/a/13234930/2238082

Before: 
😢
<img width="1280" alt="screen shot 2017-08-30 at 7 26 40 pm" src="https://user-images.githubusercontent.com/2877920/29884112-0dec60d2-8dbb-11e7-9c69-3bbd08f8c911.png">

After:
🤓
<img width="821" alt="screen shot 2017-08-30 at 7 43 44 pm" src="https://user-images.githubusercontent.com/2877920/29884285-a5130056-8dbb-11e7-9d4a-d39efae1a313.png">


Adding this line solves my issues:

https://github.com/cossacklabs/themis/issues/128
https://github.com/cossacklabs/themis/issues/219

